### PR TITLE
Removed kotlin stdlib declarations

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -35,8 +35,6 @@ android {
 dependencies {
     api project(":domain")
 
-    api "org.jetbrains.kotlin:kotlin-stdlib:$rootProject.kotlinVersion"
-
     // Cloud Firestore
     implementation "com.google.firebase:firebase-firestore-ktx:$rootProject.firestoreVersion"
     // Firebase Authentication

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -10,8 +10,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib:$rootProject.kotlinVersion"
-
     // RxJava
     implementation "io.reactivex.rxjava3:rxandroid:$rootProject.rxAndroidVersion"
     api "io.reactivex.rxjava3:rxjava:$rootProject.rxJavaVersion"


### PR DESCRIPTION
As of Kotlin v1.4.0 you no longer need to declare the stdlib dependency because it is added by default.