### PR TITLE
Fixed the Gradle assemble command failing

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -45,6 +45,9 @@ dependencies {
                 "I would rather spend elsewhere." +
                 "I am excluding the material library so I can continue using an older version of it."
     }
+    implementation ("com.google.android.material:material:$rootProject.materialDesignVersion") {
+        because "This fixes the Gradle `assemble` command failing. This dependency is required by Firebase UI."
+    }
     implementation "com.google.firebase:firebase-auth-ktx:$rootProject.firebaseAuthVersion"
     implementation "com.google.android.gms:play-services-auth:$rootProject.playServicesAuthVersion"
 


### PR DESCRIPTION
If a debug or release APK is built via Android Studio's GUI, it builds without an issue. If an APK is built via the command line, specifically the `assemble` command, the build fails stating that it cannot link a resource  file in the data module.

The issue has to do with the Firebase UI dependency. The compiler cannot find the aforementioned resource file because the data module does not contain the design library resources required by the Firebase UI dependency.