### PR TITLE
Removed Splitties dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,9 +96,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$rootProject.lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$rootProject.lifecycleVersion"
 
-    // Splitties
-    implementation "com.louiscad.splitties:splitties-toast:$splittiesVersion"
-
     // Navigation
     implementation "androidx.navigation:navigation-runtime-ktx:$rootProject.navVersion"
     implementation "androidx.navigation:navigation-fragment-ktx:$rootProject.navVersion"

--- a/app/src/main/java/com/precopia/david/lists/common/AndroidExt.kt
+++ b/app/src/main/java/com/precopia/david/lists/common/AndroidExt.kt
@@ -1,15 +1,16 @@
 package com.precopia.david.lists.common
 
 import android.app.Application
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
-import splitties.toast.toast
 
 val Fragment.application: Application
     get() = activity!!.application
 
-fun Fragment.toast(message: String) = toast(message)
+fun Fragment.toast(message: String) =
+        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
 
 fun Fragment.navigate(direction: NavDirections) {
     findNavController().navigate(direction)

--- a/app/src/main/java/com/precopia/david/lists/view/authentication/AuthView.kt
+++ b/app/src/main/java/com/precopia/david/lists/view/authentication/AuthView.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
@@ -17,7 +18,6 @@ import com.precopia.david.lists.view.authentication.IAuthContract.LogicEvents
 import com.precopia.david.lists.view.authentication.IAuthContract.ViewEvents
 import com.precopia.david.lists.view.authentication.buildlogic.DaggerAuthComponent
 import kotlinx.android.synthetic.main.auth_view.*
-import splitties.toast.longToast
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -115,7 +115,7 @@ class AuthView : Fragment(R.layout.auth_view), IAuthContract.View {
     }
 
     private fun displayMessage(message: String) {
-        longToast(message)
+        Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
     }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
 
         kotlinVersion = '1.4.0'
         coreKtxVersion = "1.3.1"
-        splittiesVersion = "2.1.1"
         navVersion = "2.3.0"
         appCompatVersion = "1.2.0"
         materialDesignVersion = "1.0.0"


### PR DESCRIPTION
The Splitties dependency still relies upon the depreciated Android Support libraries, thus Jetifier needs to be enabled. Jetifer increases build time. In particular case, considering this Splitties dependency was small, the increase in build time was minimal. Regardless, I want to move towards being able to disable Jetifier. Additionally, the helpfulness of this library was minimal.